### PR TITLE
Update style.css

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -7,7 +7,7 @@
   border: none;
   border-radius: 0;
   min-height: 0;
-  font-family: CaskaydiaMono Nerd Font;
+  font-family: CaskaydiaMono Nerd Font Propo;
   font-size: 12px;
 }
 
@@ -30,12 +30,15 @@
   opacity: 0.5;
 }
 
+#pulseaudio {
+  font-family: CaskaydiaMono Nerd Font;
+}
+
 #tray,
 #cpu,
 #battery,
 #network,
 #bluetooth,
-#pulseaudio,
 #custom-omarchy,
 #custom-update {
   min-width: 12px;


### PR DESCRIPTION
Fixes the uneven spacing between icons on waybar by updating styling.css with Propo font family. However, Propo introduces a small issue as the volume icons don't have the same with. As a consequence, icons left of volume will move based on the displayed volume icon. To solve this, I added a non-Propo font to the pipewire module as well - this way the volume icons have fixed length but eats a bit into the spacing towards the CPU icon. But I see this as the best trade-off.